### PR TITLE
Add a `on_continue_user_activity` delegate method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7.2
 before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion

--- a/app/screens/test_delegate.rb
+++ b/app/screens/test_delegate.rb
@@ -1,7 +1,8 @@
 class TestDelegate < ProMotion::Delegate
   status_bar false
 
-  attr_accessor :called_on_load, :called_will_load, :called_on_activate, :called_will_deactivate, :called_on_enter_background, :called_will_enter_foreground, :called_on_unload, :called_on_tab_selected
+  attr_accessor :called_on_load, :called_will_load, :called_on_activate, :called_will_deactivate, :called_on_enter_background, :called_will_enter_foreground, :called_on_unload, :called_on_tab_selected, :called_on_continue_user_activity, :user_activity, :restoration_handler
+
   def on_load(app, options)
     self.called_on_load = true
   end
@@ -32,5 +33,11 @@ class TestDelegate < ProMotion::Delegate
 
   def on_tab_selected(vc)
     self.called_on_tab_selected = true
+  end
+
+  def on_continue_user_activity(params = {})
+    self.called_on_continue_user_activity = true
+    self.user_activity = params[:user_activity]
+    self.restoration_handler = params[:restoration_handler]
   end
 end

--- a/docs/Reference/ProMotion Delegate.md
+++ b/docs/Reference/ProMotion Delegate.md
@@ -131,6 +131,17 @@ def on_open_url(args = {})
 end
 ```
 
+#### on_continue_user_activity(args = {})
+
+Fires when the application is opened with a `NSUserActivity` (utilizing [application:continueUserActivity:restorationHandler:](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplicationDelegate_Protocol/index.html#//apple_ref/occ/intfm/UIApplicationDelegate/application:continueUserActivity:restorationHandler:)).
+
+```ruby
+def on_continue_user_activity(asrgs = {})
+  args[:user_activity]        #=> the object that describes the activity (NSUserActivity)
+  args[:restoration_handler]  #=> a block, that yields an array of restorable objects, ie. objects that respond to a `restoreActivityState` method.
+end
+```
+
 ---
 
 ### Class Methods

--- a/lib/ProMotion/delegate/delegate_module.rb
+++ b/lib/ProMotion/delegate/delegate_module.rb
@@ -43,6 +43,10 @@ module ProMotion
       try :on_open_url, { url: url, source_app: source_app, annotation: annotation }
     end
 
+    def application(application, continueUserActivity:user_activity, restorationHandler:restoration_handler)
+      try :on_continue_user_activity, { user_activity: user_activity, restoration_handler: restoration_handler }
+    end
+
     def ui_window
       (defined?(Motion) && defined?(Motion::Xray) && defined?(Motion::Xray::XrayWindow)) ? Motion::Xray::XrayWindow : UIWindow
     end

--- a/spec/unit/delegate_spec.rb
+++ b/spec/unit/delegate_spec.rb
@@ -79,6 +79,24 @@ describe "PM::Delegate" do
 
     @subject.application(UIApplication.sharedApplication, openURL: url, sourceApplication:sourceApplication, annotation: annotation)
   end
+
+  describe "#on_continue_user_activity" do
+    before do
+      @subject.application(UIApplication.sharedApplication, continueUserActivity: {}, restorationHandler: [])
+    end
+
+    it "should call on_continue_user_activity when launching with a user activity" do
+      @subject.called_on_continue_user_activity.should == true
+    end
+
+    it "should pass the user activity" do
+      @subject.user_activity.should == {}
+    end
+
+    it "should pass the restoration_handler" do
+      @subject.restoration_handler.should == []
+    end
+  end
 end
 
 # iOS 7 ONLY tests


### PR DESCRIPTION
In iOS 9, there is a delegate method to handle opening the app from
notifications and Handoff from other devices.

This implements support for an `on_continue_user_activity` method that
gets triggered when the app is opened with an activity.
